### PR TITLE
Add line items model/controller for handling cart items

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -10,7 +10,7 @@ class BooksController < ApplicationController
   end
 
   def show
-    @order_item = cart.order_items.new
+    @line_item = cart.line_items.new
   end
 
   private

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,6 +1,6 @@
 class CartsController < ApplicationController
   def show
     @cart = cart
-    @order_items = cart.order_items
+    @line_items = cart.line_items
   end
 end

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -1,0 +1,39 @@
+class LineItemsController < ApplicationController
+  before_action :set_order, only: [:update, :destroy]
+  def create
+    @line_item = cart.line_items.new(line_item_params)
+    if cart.save
+      redirect_to cart_path(cart)
+    else
+      redirect_to root_path
+    end
+  end
+
+  def update
+    if @line_item.update(line_item_params)
+      cart.save
+      redirect_to cart_path(cart)
+    else
+      redirect_to cart_path(cart), alert: "Item could not be updated"
+    end
+  end
+
+  def destroy
+    if @line_item.destroy
+      cart.save
+      redirect_to cart_path(cart)
+    else
+      redirect_to cart_path(cart), alert: "Item could not be removed"
+    end
+  end
+
+  private
+
+  def set_order
+    @line_item = cart.line_items.find_by(id: params[:id])
+  end
+
+  def line_item_params
+    params.require(:line_item).permit(:book_id, :quantity)
+  end
+end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,10 +1,10 @@
 class Cart < ActiveRecord::Base
   belongs_to  :user
-  has_many    :order_items
+  has_many    :line_items
   before_save :update_total
 
   def calculate_total
-    order_items.inject(0) { |sum, item| sum + item.total_price }
+    line_items.inject(0) { |sum, item| sum + item.total_price }
   end
 
   private

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -1,0 +1,15 @@
+class LineItem < ActiveRecord::Base
+  belongs_to :cart
+  belongs_to :book
+
+  validates :cart, :book, presence: true
+  delegate :title, to: :book
+
+  def unit_price
+    book.price
+  end
+
+  def total_price
+    unit_price * quantity
+  end
+end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -6,13 +6,14 @@ class OrderItem < ActiveRecord::Base
   validates :quantity, presence: true, numericality: { greater_than: 0 }
   validates :book, presence: true
 
+  before_create :set_prices
+
   delegate :title, to: :book
 
-  def unit_price
-    book.price
-  end
+  private
 
-  def total_price
-    unit_price * quantity
+  def set_prices
+    self.unit_price = book.price
+    self.total_price = unit_price * quantity
   end
 end

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -8,7 +8,7 @@
   <p> <%= @book.category %> </p>
 
   <h4> Buy it now for only $<%= @book.price %></h4>
-  <%= simple_form_for(@order_item) do |f| %>
+  <%= simple_form_for(@line_item) do |f| %>
     <%= f.input :book_id, as: :hidden, input_html: { value: @book.id } %>
     <%= f.input :quantity, input_html: { value: 1 } %>
     <%= f.button :submit, "Add to Cart" %>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -6,14 +6,14 @@
 </div>
 
 <div class="cart-item-list">
-  <% @order_items.each do |item| %>
+  <% @line_items.each do |item| %>
     <div class="row cart-item-row">
       <div class="col-md-3 cart-item-title"><%= link_to item.title, book_path(item.book) %></div>
       <div class="col-md-2 cart-item-total_price">$<%= item.total_price %></div>
       <div class="col-md-2 cart-item-unit_price">$<%= item.unit_price %></div>
       <div class="col-md-3 cart-item-quantity"><%= render 'quantity', item: item %></div>
       <div class="col-md-2 cart-item-remove">
-        <%= link_to "Remove", order_item_path(item), method: :delete,
+        <%= link_to "Remove", line_item_path(item), method: :delete,
           data: { confirm: "Are you sure" }, class: "btn btn-primary" %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   devise_for :admins, path: 'admin'
   devise_for :users
   resources :books, only: [:index, :show]
+  resources :line_items, only: [:create, :update, :destroy]
   resources :order_items, only: [:create, :update, :destroy]
   resources :carts, only: :show
   namespace :admin do

--- a/db/migrate/20160204145815_create_line_items.rb
+++ b/db/migrate/20160204145815_create_line_items.rb
@@ -1,0 +1,11 @@
+class CreateLineItems < ActiveRecord::Migration
+  def change
+    create_table :line_items do |t|
+      t.references :cart, index: true, foreign_key: true
+      t.references :book, index: true, foreign_key: true
+      t.integer :quantity
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160203193904) do
+ActiveRecord::Schema.define(version: 20160204145815) do
 
   create_table "admins", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -50,6 +50,17 @@ ActiveRecord::Schema.define(version: 20160203193904) do
   end
 
   add_index "carts", ["user_id"], name: "index_carts_on_user_id"
+
+  create_table "line_items", force: :cascade do |t|
+    t.integer  "cart_id"
+    t.integer  "book_id"
+    t.integer  "quantity"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "line_items", ["book_id"], name: "index_line_items_on_book_id"
+  add_index "line_items", ["cart_id"], name: "index_line_items_on_cart_id"
 
   create_table "order_items", force: :cascade do |t|
     t.integer  "book_id"

--- a/features/step_definitions/purchase_steps.rb
+++ b/features/step_definitions/purchase_steps.rb
@@ -8,7 +8,7 @@ When(/^I click on a book$/) do
 end
 
 When(/^I adjust the quantity of the book to (\d+)$/) do |number|
-  fill_in "order_item_quantity", with: number
+  fill_in "line_item_quantity", with: number
   click_button("Update")
 end
 
@@ -22,9 +22,9 @@ end
 
 Then(/^the book is added to my cart$/) do
   @cart = @user.cart
-  expect(@cart.order_items).to_not eq(nil)
-  last_order_item = @cart.order_items.last
-  expect(last_order_item.book).to eq(@book)
+  expect(@cart.line_items).to_not eq(nil)
+  last_line_item = @cart.line_items.last
+  expect(last_line_item.book).to eq(@book)
 end
 
 Then(/^I see the book in my cart$/) do
@@ -33,14 +33,14 @@ end
 
 Then(/^the book is added to my cart with quantity (\d+)$/) do |number|
   @cart = @user.cart
-  last_order_item = @cart.order_items.last
+  last_line_item = @cart.line_items.last
 
-  expect(@cart.order_items).to_not eq(nil)
-  expect(last_order_item.book).to eq(@book)
-  expect(last_order_item.quantity).to eq(number.to_i)
+  expect(@cart.line_items).to_not eq(nil)
+  expect(last_line_item.book).to eq(@book)
+  expect(last_line_item.quantity).to eq(number.to_i)
 end
 
 Then(/^I see the book in my cart with quantity (\d+)$/) do |number|
   expect(page).to have_content(@book.title)
-  find(:css, "#order_item_quantity").value == number
+  find(:css, "#line_item_quantity").value == number
 end

--- a/spec/factories/line_items.rb
+++ b/spec/factories/line_items.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :line_item do
+    book
+    cart
+    quantity 1
+  end
+end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -2,23 +2,23 @@ require 'rails_helper'
 
 RSpec.describe Cart, type: :model do
   it { is_expected.to belong_to(:user) }
-  it { is_expected.to have_many(:order_items) }
+  it { is_expected.to have_many(:line_items) }
 
   describe "#calculate_total" do
     let(:cart) { create(:cart) }
-    let(:item_1) { create(:order_item, cart: cart) }
-    let(:item_2) { create(:order_item, cart: cart) }
+    let(:item_1) { create(:line_item, cart: cart) }
+    let(:item_2) { create(:line_item, cart: cart) }
     it "calculates the total price for the order" do
-      cart.order_items << item_1
-      cart.order_items << item_2
+      cart.line_items << item_1
+      cart.line_items << item_2
       expect(cart.calculate_total).to eq(item_1.total_price + item_2.total_price)
     end
 
     it "calculates the total price for the order" do
       item_1.book.price = 10
       item_2.book.price = 20
-      cart.order_items << item_1
-      cart.order_items << item_2
+      cart.line_items << item_1
+      cart.line_items << item_2
       expect(cart.calculate_total).to eq(30)
     end
   end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -5,21 +5,14 @@ RSpec.describe Cart, type: :model do
   it { is_expected.to have_many(:line_items) }
 
   describe "#calculate_total" do
-    let(:cart) { create(:cart) }
-    let(:item_1) { create(:line_item, cart: cart) }
-    let(:item_2) { create(:line_item, cart: cart) }
+    let(:cart)    { create(:cart) }
+    let(:book_1)  { create(:book, price: 10) }
+    let(:book_2)  { create(:book, price: 20) }
+    let!(:item_1) { create(:line_item, cart: cart, book: book_1) }
+    let!(:item_2) { create(:line_item, cart: cart, book: book_2) }
     it "calculates the total price for the order" do
-      cart.line_items << item_1
-      cart.line_items << item_2
-      expect(cart.calculate_total).to eq(item_1.total_price + item_2.total_price)
-    end
-
-    it "calculates the total price for the order" do
-      item_1.book.price = 10
-      item_2.book.price = 20
-      cart.line_items << item_1
-      cart.line_items << item_2
-      expect(cart.calculate_total).to eq(30)
+      expect(cart.reload.calculate_total).to eq(item_1.total_price + item_2.total_price)
+      expect(cart.reload.calculate_total).to eq(30)
     end
   end
 end

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe LineItem, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:cart) }
+    it { is_expected.to belong_to(:book) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:book) }
+    it { is_expected.to validate_presence_of(:cart) }
+  end
+
+  describe "#unit_price" do
+    let(:book) { create(:book, price: 5) }
+    let(:line_item) { create(:line_item, book: book) }
+    it "returns the price of the line_item's book" do
+      expect(line_item.unit_price).to eq(5)
+    end
+  end
+
+  describe "#total_price" do
+    let(:book) { create(:book, price: 5) }
+    let(:line_item) { create(:line_item, book: book, quantity: 4) }
+    it "returns the total price of itself (unit_price * quantity)" do
+      expect(line_item.total_price).to eq(20)
+    end
+  end
+end


### PR DESCRIPTION
### Why?
https://github.com/smashingboxes/apprenticeship/tree/master/Curriculum/Backend/bookstore
Because items in the cart behave differently than items that have been ordered
Because cart.order_items and order.order_items would just confuse everyone involved

### What Changed?
Added a LineItem model and controller to handle items in the cart
OrderItems now only refer to purchased items