### PR TITLE
Change tape host to master branch

### DIFF
--- a/taperole/hosts
+++ b/taperole/hosts
@@ -1,6 +1,6 @@
 # Base Example
 [production]
-162.243.113.173 be_app_env=production be_app_branch=bugfix/api-keys
+162.243.113.173 be_app_env=production be_app_branch=master
 
 [omnibox:children]
 production


### PR DESCRIPTION
### Why?
https://github.com/smashingboxes/apprenticeship/tree/master/Curriculum/Backend/bookstore
Because master is stable (typically).

### What Changed?
Tape hosts change from bugfix branch to master